### PR TITLE
Gaelic translation fix.

### DIFF
--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -1398,7 +1398,7 @@ msgstr "Ceanglaidh an còd air an taobh chlì ri duilleag %1 le còd QR."
 
 #. English: "Recently played".
 msgid "recently_played"
-msgstr "Air a chluich o chionn gohirid"
+msgstr "Air a chluich o chionn ghoirid"
 
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".


### PR DESCRIPTION
Typo fix, it was:
"Air a chluich o chionn **gohirid**"

It should be:
"Air a chluich o chionn **ghoirid**"

See Jira ticket: https://jira.dev.bbc.co.uk/browse/IPR-2553