### PR TITLE
Programmes ADA: Rename "Suggested episodes" -> "Related episodes"

### DIFF
--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -1418,6 +1418,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr "عذرا، لا يوجد توصيات على هذا البرنامج."
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1797,11 +1802,6 @@ msgstr "اشتراك"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "Subscribe to podcast"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -1424,6 +1424,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr "Mae’n ddrwg gennym, does dim argymhellion ar gyfer y rhaglen yma."
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1804,11 +1809,6 @@ msgstr "Tanysgrifio"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "Tanysgrifio i bodlediad"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -1419,6 +1419,11 @@ msgstr[2] "Recipes"
 msgid "recommendations_noresults"
 msgstr "Sorry, there are no recommendations for this programme."
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr "Related episodes"
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1799,11 +1804,6 @@ msgstr "Subscribe"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "Subscribe to podcast"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr "Suggested episodes"
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -1417,6 +1417,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr "متأسفانه توصیه ای برای این برنامه موجود نیست."
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1796,11 +1801,6 @@ msgstr "مشترک شوید"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "مشترک پادکست شوید"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -1425,6 +1425,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr "Désolé, il n'y a pas de recommandations pour ce programme."
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1808,11 +1813,6 @@ msgstr "S'abonner"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "S'abonner au podcast"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -1420,6 +1420,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1799,11 +1804,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -1414,6 +1414,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1792,11 +1797,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -1415,6 +1415,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr "क्षमा कीजिए, इस कार्यक्रम के लिए कोई सुझाव नहीं है"
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1794,11 +1799,6 @@ msgstr "सब्सक्राइब"
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
 msgstr "पॉडकास्ट के लिए सब्सक्राइब करें"
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
-msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".
 #. English (one item): "There is currently 1 available episode tagged with %1".

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -1414,6 +1414,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1792,11 +1797,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -1412,6 +1412,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1790,11 +1795,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -1415,6 +1415,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1793,11 +1798,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -1413,6 +1413,11 @@ msgstr[2] ""
 msgid "recommendations_noresults"
 msgstr ""
 
+#. English: "Related episodes"
+#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
+msgid "related_episodes"
+msgstr ""
+
 #. English (no items): "Related Links".
 #. English (one item): "Related Link".
 #. English (2+ items): "Related Links".
@@ -1791,11 +1796,6 @@ msgstr ""
 
 #. English: "Subscribe to podcast".
 msgid "subscribe_to_podcast"
-msgstr ""
-
-#. English: "Suggested episodes"
-#. Example URL: http://www.bbc.co.uk/programmes/p0054631 .
-msgid "suggested_episodes"
 msgstr ""
 
 #. English (no items): "There are currently no available episodes tagged with %1".


### PR DESCRIPTION
Strictly speaking, a breaking change as I'm removing "suggested_episodes" but that never made it's way into production anyway so I'm happy to call this a point release.