### PR TITLE
RadioNav Translations

### DIFF
--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr "كل"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr "جميع الحلقات القادمة"
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr "متاحة على"
 msgid "colon_from_suppliers"
 msgstr "من الموزع"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -436,6 +451,11 @@ msgstr "هذا البرنامج ليس لديه رصيد"
 msgid "decade"
 msgstr "%1s"
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -447,9 +467,19 @@ msgstr[0] "تنزيلات"
 msgstr[1] "تنزيل"
 msgstr[2] "تنزيلات"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Duration: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr ""
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -530,6 +560,11 @@ msgstr "سوف يكون %1 حلقة. المعلومات سوف تتوفر قري
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "لا يوجد أي حلقة"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -623,6 +658,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "Hide available episodes"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr ""
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1130,6 +1170,11 @@ msgstr "المزيد من الراديو"
 msgid "more_on_tv"
 msgstr "المزيد على التلفاز"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "Music and featured items"
@@ -1151,6 +1196,11 @@ msgstr "Nations Radio"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "سلسلة جديدة "
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1271,6 +1321,11 @@ msgstr "صفحة %1"
 msgid "pagination_page"
 msgstr "صفحة %1 من %2"
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1310,6 +1365,11 @@ msgstr "More podcasts"
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr "Other podcasts you may like"
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr ""
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1422,6 +1482,11 @@ msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1466,6 +1531,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Release date: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1664,6 +1734,11 @@ msgstr "مشاهدة الاسبوع كاملا"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "أمس"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -45,6 +45,11 @@ msgstr "جميع الحلقات متاحة على راديو بي بي سي أي
 msgid "all_previous_episodes"
 msgstr "جميع الحلقات السابقة"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1361,6 +1366,11 @@ msgstr "Episodes to download"
 msgid "podcasts_more"
 msgstr "More podcasts"
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1481,6 +1491,11 @@ msgstr "يمكنك حفظ، طباعة ومشاركة الصورة"
 msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr ""
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1738,6 +1753,11 @@ msgstr "أمس"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -16,6 +16,11 @@ msgstr "Ychwanegwyd"
 msgid "all"
 msgstr "Pob un"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr "Pob Categori"
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "Popeth i ddod"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Enw’r artist"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr "Celfyddydau, Diwylliant a'r Cyfryngau"
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -361,6 +371,11 @@ msgstr "Ar gael ar"
 msgid "colon_from_suppliers"
 msgstr "Gan werthwyr"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr "Comedi"
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -438,6 +453,11 @@ msgstr "Nid oes gan y rhaglen yma restr cyfranwyr"
 msgid "decade"
 msgstr "%1au"
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr "Rhaglenni Dogfen"
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -449,9 +469,19 @@ msgstr[0] "Lawrlwythiad"
 msgstr[1] "Lawrlwythiad"
 msgstr[2] "Lawrlwythiad"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr "Drama"
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Hyd: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr "Adloniant"
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -536,6 +566,11 @@ msgstr "Bydd yna %1 o benodau. Rhagor o wybodaeth i ddod yn fuan"
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "Does dim penodau"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr "Ffeithiol"
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -629,6 +664,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "Cuddio’r penodau sydd ar gael"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr "Hanes"
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1136,6 +1176,11 @@ msgstr "Mwy ar y Radio"
 msgid "more_on_tv"
 msgstr "Mwy ar y Teledu"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr "Cerddoriaeth"
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "Cerddoriaeth ac eitemau dan sylw"
@@ -1157,6 +1202,11 @@ msgstr "Radio’r Cenhedloedd"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "cyfres newydd"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr "Newyddion"
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1277,6 +1327,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr "Perfformiadau a Digwyddiadau"
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1316,6 +1371,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr "Gwleidyddiaeth"
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1428,6 +1488,11 @@ msgid "qr_link"
 msgstr ""
 "Bydd y côd yn cysylltu â thudalen %1 trwy ddefnyddio darllenydd côd QR."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr "Darlleniadau"
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr "Chwaraewyd yn ddiweddar"
@@ -1472,6 +1537,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Dyddiad Rhyddhau: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr "Crefydd a Moeseg"
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1670,6 +1740,11 @@ msgstr "Dangos wythnos lawn"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Ddoe"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr "Gwyddoniaeth a Natur"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -45,6 +45,11 @@ msgstr "Pob pennod sydd ar gael ar BBC iPlayer Radio"
 msgid "all_previous_episodes"
 msgstr "Pob pennod blaenorol"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr "Rhaglenni yn dechrau gyda"
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1367,6 +1372,11 @@ msgstr "Penodau i’w lawrlwytho"
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr "Chwilio"
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1487,6 +1497,11 @@ msgstr "Gallwch arbed, argraffu neu rannu'r llun."
 msgid "qr_link"
 msgstr ""
 "Bydd y côd yn cysylltu â thudalen %1 trwy ddefnyddio darllenydd côd QR."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr "Rhaglenni"
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1745,6 +1760,11 @@ msgstr "Ddoe"
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
 msgstr "Gwyddoniaeth a Natur"
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
+msgstr "Chwilio yn iPlayer Radio"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -16,6 +16,11 @@ msgstr "Added"
 msgid "all"
 msgstr "All"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr "All Categories"
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "All upcoming"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Artist name"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr "Arts, Culture &amp; the Media"
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr "Available on"
 msgid "colon_from_suppliers"
 msgstr "From suppliers"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr "Comedy"
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -436,6 +451,11 @@ msgstr "This programme has no credits"
 msgid "decade"
 msgstr "%1s"
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr "Documentaries"
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -447,9 +467,19 @@ msgstr[0] "Downloads"
 msgstr[1] "Download"
 msgstr[2] "Downloads"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr "Drama"
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Duration: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr "Entertainment"
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -530,6 +560,11 @@ msgstr "There will be %1 episodes. More information coming soon"
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "There are no episodes"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr "Factual"
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -624,6 +659,11 @@ msgstr "GMT"
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "Hide available episodes"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr "History"
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1131,6 +1171,11 @@ msgstr "More on Radio"
 msgid "more_on_tv"
 msgstr "More on TV"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr "Music"
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "Music and featured items"
@@ -1152,6 +1197,11 @@ msgstr "Nations Radio"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "New series"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr "News"
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1272,6 +1322,11 @@ msgstr "Page %1"
 msgid "pagination_page"
 msgstr "Page %1 of %2"
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr "Performances &amp; Events"
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1311,6 +1366,11 @@ msgstr "More podcasts"
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr "Other podcasts you may like"
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr "Politics"
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1423,6 +1483,11 @@ msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr "Readings"
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr "Recently played"
@@ -1467,6 +1532,11 @@ msgstr "Related topics"
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Release date: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr "Religion &amp; Ethics"
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1666,6 +1736,11 @@ msgstr "Show full week"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Yesterday"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr "Science &amp; Nature"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -45,6 +45,11 @@ msgstr "All episodes available on BBC iPlayer Radio"
 msgid "all_previous_episodes"
 msgstr "All previous episodes"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr "All programmes beginning with"
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1362,6 +1367,11 @@ msgstr "Episodes to download"
 msgid "podcasts_more"
 msgstr "More podcasts"
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr "Search"
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1482,6 +1492,11 @@ msgstr "You may save, print or share the image."
 msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr "Programmes"
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1741,6 +1756,11 @@ msgstr "Yesterday"
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
 msgstr "Science &amp; Nature"
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
+msgstr "Search iPlayer Radio"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -44,6 +44,11 @@ msgstr "همه قسمت‎‌‌های قابل دسترسی در آی‌پلی�
 msgid "all_previous_episodes"
 msgstr "همه قسمت‌های قبلی"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1361,6 +1366,11 @@ msgstr "قسمت‌های برنامه برای دانلود"
 msgid "podcasts_more"
 msgstr "قسمت‌های بیشتر"
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1480,6 +1490,11 @@ msgstr "شما می توانید این تصویر را ذخیره، چاپ یا
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "این کد با استفاده از کد خوان کیو آر صفحه اینترنتی %1 را باز خواهد کرد."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr ""
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1737,6 +1752,11 @@ msgstr "دیروز"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -15,6 +15,11 @@ msgstr ""
 msgid "all"
 msgstr "همه"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr "همه  قسمت‌های بعدی"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "نام هنرمند"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -359,6 +369,11 @@ msgstr "قابل دسترسی از"
 msgid "colon_from_suppliers"
 msgstr "از عرضه‌کنندگان"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -434,6 +449,11 @@ msgstr "این برنامه تیتراژ پایانی ندارد"
 msgid "decade"
 msgstr "%1"
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -445,9 +465,19 @@ msgstr[0] "دانلودها"
 msgstr[1] "دانلود"
 msgstr[2] "دانلودها"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "مدت:  %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr ""
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -528,6 +558,11 @@ msgstr "%1 قسمت برنامه موجود خواهد بود. اطلاعات ب
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "هیچ قسمتی از برنامه موجود نیست."
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -623,6 +658,11 @@ msgstr "گرینویچ"
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "پنهان کردن قسمت‌های موجود برنامه"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr ""
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1130,6 +1170,11 @@ msgstr "بیشتر از رادیو"
 msgid "more_on_tv"
 msgstr "بیشتر از تلویزیون"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "برنامه‌های موسیقی و برگزیده"
@@ -1151,6 +1196,11 @@ msgstr "؟؟"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "مجموعه‌های تازه"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1271,6 +1321,11 @@ msgstr "صفحه %1"
 msgid "pagination_page"
 msgstr "صفحه %1 از  %2"
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1310,6 +1365,11 @@ msgstr "قسمت‌های بیشتر"
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr "سایر پادکست‌هایی که ممکن است علاقمند باشید"
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr ""
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1421,6 +1481,11 @@ msgstr "شما می توانید این تصویر را ذخیره، چاپ یا
 msgid "qr_link"
 msgstr "این کد با استفاده از کد خوان کیو آر صفحه اینترنتی %1 را باز خواهد کرد."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1465,6 +1530,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "تاریخ انتشار: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1663,6 +1733,11 @@ msgstr "نشان دادن تمام هفته"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "دیروز"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr "Tout"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "Prochainement"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Nom de l'artiste"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -361,6 +371,11 @@ msgstr "Disponible sur"
 msgid "colon_from_suppliers"
 msgstr "Des fournisseurs"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -438,6 +453,11 @@ msgstr "Ce programme n'a pas de crédits"
 msgid "decade"
 msgstr "années %1"
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -449,9 +469,19 @@ msgstr[0] "Téléchargements"
 msgstr[1] "Téléchargement"
 msgstr[2] "Téléchargements"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Durée: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr ""
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -533,6 +563,11 @@ msgstr "Il y aura %1 épisodes. Plus d'informations à venir"
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "Il n'y a pas d'épisode"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -628,6 +663,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "Cacher épisodes disponibles"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr ""
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1135,6 +1175,11 @@ msgstr "Plus sur la Radio"
 msgid "more_on_tv"
 msgstr "Plus à la TV"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "Music et autres"
@@ -1156,6 +1201,11 @@ msgstr "Nations Radio"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "Nouvelle série"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1276,6 +1326,11 @@ msgstr "Page %1"
 msgid "pagination_page"
 msgstr "Page %1 sur %2"
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1315,6 +1370,11 @@ msgstr "Plus de podcasts"
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr "Autres podcasts que vous aimerez"
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr ""
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1429,6 +1489,11 @@ msgstr ""
 "Ce code vous amènera à la page de %1 lorsqu'il sera lu avec un lecteur de "
 "code QR."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1473,6 +1538,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Date de sortie: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1673,6 +1743,11 @@ msgstr "Montrer semaine entière"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Hier"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -45,6 +45,11 @@ msgstr "Tous les épisodes disponibles sur BBC iPlayer Radio"
 msgid "all_previous_episodes"
 msgstr "Tous les épisodes précédents"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1366,6 +1371,11 @@ msgstr "Épisodes à télécharger"
 msgid "podcasts_more"
 msgstr "Plus de podcasts"
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1488,6 +1498,11 @@ msgid "qr_link"
 msgstr ""
 "Ce code vous amènera à la page de %1 lorsqu'il sera lu avec un lecteur de "
 "code QR."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr ""
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1747,6 +1762,11 @@ msgstr "Hier"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -16,6 +16,11 @@ msgstr "Curtha Leis"
 msgid "all"
 msgstr "Uile"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr "Gach Catagóir"
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "Gach eagrán roimhe seo"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Ainm cheoltóra"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr "Na hEalaíona, Cultúr &amp; na Meáin"
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr "Ar fáil ar"
 msgid "colon_from_suppliers"
 msgstr "Ó sholáthraithe"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr "Greann"
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -437,6 +452,11 @@ msgstr "Níl teidil chreidiúna leis an chlár seo"
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr "Cláir Faisnéise"
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -448,9 +468,19 @@ msgstr[0] "Íoslódáil"
 msgstr[1] "Íoslódáil"
 msgstr[2] " Íoslódálacha"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr "Drámaí"
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Fad: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr "Siamsaíocht"
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -531,6 +561,11 @@ msgstr "Beidh %1 eagrán ann. Tuilleadh eolais le theacht go luath"
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "Níl aon eagrán ann"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr "Cláir Fíorasacha"
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -624,6 +659,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr "Stair"
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1131,6 +1171,11 @@ msgstr "Tuilleadh ar Ráidió"
 msgid "more_on_tv"
 msgstr "Tuilleadh ar Teilifís"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr "Ceol"
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "Ceol agus míreanna faoi thrácht"
@@ -1152,6 +1197,11 @@ msgstr "Ráidió na Náisiún"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "sraith nua"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr "Nuacht"
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1272,6 +1322,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr "Taibhithe &amp; Imeachtaí"
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1311,6 +1366,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr "Polaitíocht"
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1424,6 +1484,11 @@ msgstr ""
 "Déanfaidh an cód seo nasc chuig an leathanach do %1 má bhíonn léitheoir cód "
 "QR cumasithe."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr "Léamha"
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr "Seinnte le gairid"
@@ -1468,6 +1533,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Dáta Scaoileadh: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr "Reiligiún &amp; Eitic"
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1666,6 +1736,11 @@ msgstr ""
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Inné"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr "Eolaíocht &amp; Nádúr"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -45,6 +45,11 @@ msgstr "Níl an clár seo ar fáil ar BBC iPlayer Radio faoi láthair"
 msgid "all_previous_episodes"
 msgstr "Gach eagrán roimhe seo"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr "Gach clár dar tús"
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1362,6 +1367,11 @@ msgstr "Eagráin le híoslódáil"
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr "Cuardaigh"
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1483,6 +1493,11 @@ msgid "qr_link"
 msgstr ""
 "Déanfaidh an cód seo nasc chuig an leathanach do %1 má bhíonn léitheoir cód "
 "QR cumasithe."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr "Cláir"
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1741,6 +1756,11 @@ msgstr "Inné"
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
 msgstr "Eolaíocht &amp; Nádúr"
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
+msgstr "Cuardaigh iPlayer Radio"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr "Prògraman a' tòiseachadh le"
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr "Lorg"
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1476,6 +1486,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "Ceanglaidh an còd air an taobh chlì ri duilleag %1 le còd QR."
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr "Prògraman"
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1734,6 +1749,11 @@ msgstr "An-dè"
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
 msgstr "Saidheans &amp; Nàdar"
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
+msgstr "Lorg air iPlayer Radio"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -16,6 +16,11 @@ msgstr "Air a chur ris"
 msgid "all"
 msgstr "Uile"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr "Na roinnean air fad"
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr ""
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Ainm"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr "Na h-Ealain, Cultar &amp; Na Meadhanan"
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr "Comadaidh"
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr "Prògraman Aithriseach"
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,9 +466,19 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr "Dràma"
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "Fad: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr "Dibhearsain"
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -529,6 +559,11 @@ msgstr "Bidh %1 prògraman ann. Tuilleadh fiosrachaidh a dh'aithghearr"
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "Chan eil prògraman ri fhaotainn"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr "Aithriseach"
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -622,6 +657,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr "Eachdraidh"
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr "Ceòl"
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1150,6 +1195,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "new_series"
 msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr "Naidheachdan"
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr "Tachartasan"
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1309,6 +1364,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr "Poilitigs"
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr "Ceanglaidh an còd air an taobh chlì ri duilleag %1 le còd QR."
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr "Leughaidhean"
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr "Air a chluich o chionn ghoirid"
@@ -1461,6 +1526,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr "Creideamh &amp; Beus-eòlas"
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1659,6 +1729,11 @@ msgstr ""
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "An-dè"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr "Saidheans &amp; Nàdar"
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -46,6 +46,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr "Duka sauran shirye-shirye"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1361,6 +1366,11 @@ msgstr "shirye-shiryen da aka sauke"
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1476,6 +1486,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1734,6 +1749,11 @@ msgstr "Jiya"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -17,6 +17,11 @@ msgstr ""
 msgid "all"
 msgstr "Duka"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -51,6 +56,11 @@ msgstr "Wadanda ke tafe"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Sunan mawaki"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -361,6 +371,11 @@ msgstr "Za a samu a"
 msgid "colon_from_suppliers"
 msgstr "Daga masu samarwa"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -436,6 +451,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -447,8 +467,18 @@ msgstr[0] "Sauko"
 msgstr[1] "Sauko"
 msgstr[2] "Sauko"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -529,6 +559,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -622,6 +657,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1130,6 +1170,11 @@ msgstr "Sauran a rediyo"
 msgid "more_on_tv"
 msgstr "sauran a talabijin"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1151,6 +1196,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "Sababbin shirye-shirye"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1271,6 +1321,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1309,6 +1364,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1418,6 +1478,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1462,6 +1527,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Ranar da za a saki %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1660,6 +1730,11 @@ msgstr "Nuna mako baki daya"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Jiya"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -45,6 +45,11 @@ msgstr "सभी अंक बीबीसी आइप्लेयर रे�
 msgid "all_previous_episodes"
 msgstr "सभी पूर्व प्रसारित अंक"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr "डाउनलोड करने के लिए कार्यक�
 msgid "podcasts_more"
 msgstr "और अधिक पॉडकास्ट"
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1478,6 +1488,11 @@ msgstr "इस इमेज को आप सेव, प्रिंट या �
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "क्यूआर कोड रीडर का इस्तेमाल करके पढ़े जाने पर ये कोड %1 के लिए बने पेज पर ले जाएगा"
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
+msgstr ""
 
 #. English: "Readings".
 #. Used by: RadioNav -> Categories
@@ -1735,6 +1750,11 @@ msgstr "कल"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr "सभी"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "आने वाले सभी कार्यक्रम"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "कलाकार का नाम"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr "यहाँ उपलब्ध है"
 msgid "colon_from_suppliers"
 msgstr "सप्लायर की ओर से"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr "इस कार्यक्रम में क्रे़डिट �
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,9 +466,19 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
 msgstr "समय: %1"
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
+msgstr ""
 
 #. English: "This episode will be available soon".
 #. Priority for: Programmes
@@ -529,6 +559,11 @@ msgstr "%1 अंक मौजूद होगा. ज़्यादा जा�
 #. English: "There are no episodes".
 msgid "episodes_none"
 msgstr "कोई अंक नहीं हैं"
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
+msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
 #. Priority for: Programmes
@@ -622,6 +657,11 @@ msgstr ""
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
 msgstr "उपलब्ध अंकों को छिपाएँ"
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
+msgstr ""
 
 #. English: "Home".
 #. Example URL: http://www.bbc.co.uk/programmes/p023w9fy .
@@ -1129,6 +1169,11 @@ msgstr "रेडियो पर और"
 msgid "more_on_tv"
 msgstr "टीवी पर और"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr "संगीत और फ़ीचर आइटम"
@@ -1150,6 +1195,11 @@ msgstr "राष्ट्र रेडियो"
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "नई श्रृंखला"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1270,6 +1320,11 @@ msgstr "%1 पेज"
 msgid "pagination_page"
 msgstr "%2 का पेज %1"
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1309,6 +1364,11 @@ msgstr "और अधिक पॉडकास्ट"
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
 msgstr "अन्य पॉडकास्ट जो शायद आपको पसंद आएं"
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
+msgstr ""
 
 #. English: "Previous".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1419,6 +1479,11 @@ msgstr "इस इमेज को आप सेव, प्रिंट या �
 msgid "qr_link"
 msgstr "क्यूआर कोड रीडर का इस्तेमाल करके पढ़े जाने पर ये कोड %1 के लिए बने पेज पर ले जाएगा"
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1463,6 +1528,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "जारी किए जाने की तारीख़: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1661,6 +1731,11 @@ msgstr "पूरा सप्ताह दिखाइए"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "कल"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr "Бардыгы"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "Жакында болчу программалар"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Артисттин аты"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr "Бул жерден ойнотсоңуз болот"
 msgid "colon_from_suppliers"
 msgstr "Камсыз кылуучулардан"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] "Көчүрүлгөндөр"
 msgstr[1] "Көчүрүлгөн"
 msgstr[2] "Көчүрүлгөндөр"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -622,6 +657,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1130,6 +1170,11 @@ msgstr "Радио боюнча толугураак"
 msgid "more_on_tv"
 msgstr "Теле боюнча толугураак"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1151,6 +1196,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "Жаңы берүүлөр"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1271,6 +1321,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1309,6 +1364,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1418,6 +1478,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1462,6 +1527,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Жарыяланган күн: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1660,6 +1730,11 @@ msgstr "Бүтүндөй аптаны көрсөт"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Кечээ"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -45,6 +45,11 @@ msgstr "BBC iPlayer радиосундагы бардык эпизоддор"
 msgid "all_previous_episodes"
 msgstr "Буга чейинки бардык эпизоддор"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1361,6 +1366,11 @@ msgstr "Көчүрүлө турган эпизоддор"
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1476,6 +1486,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1734,6 +1749,11 @@ msgstr "Кечээ"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -15,6 +15,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -48,6 +53,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -359,6 +369,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -434,6 +449,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -445,8 +465,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -527,6 +557,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -620,6 +655,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1128,6 +1168,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1148,6 +1193,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1269,6 +1319,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1307,6 +1362,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1416,6 +1476,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1459,6 +1524,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1657,6 +1727,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -44,6 +44,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1359,6 +1364,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1474,6 +1484,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1732,6 +1747,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -45,6 +45,11 @@ msgstr "Makala zote zinazopatikana katika BBC iPlayer Radio"
 msgid "all_previous_episodes"
 msgstr "Makala zote za awali"
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1362,6 +1367,11 @@ msgstr "Makala za kupakuliwa"
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1477,6 +1487,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1735,6 +1750,11 @@ msgstr "Jana"
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr "Zote"
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -50,6 +55,11 @@ msgstr "Zote zijazo"
 #. Priority for: Rich Tracks
 msgid "artist_name"
 msgstr "Jina la msanii"
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
+msgstr ""
 
 #. English: "All Programmes".
 msgid "atoz_all"
@@ -360,6 +370,11 @@ msgstr "Inapatikana katika"
 msgid "colon_from_suppliers"
 msgstr "Kutoka kwa wawasilishaji"
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] "Zilizopakuliwa"
 msgstr[1] "Iliyopakuliwa"
 msgstr[2] "Zilizopakuliwa"
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -623,6 +658,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1131,6 +1171,11 @@ msgstr "Zaidi Redioni"
 msgid "more_on_tv"
 msgstr "Zaidi kwenye televisheni"
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1152,6 +1197,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "new_series"
 msgstr "Msururu mpya"
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
+msgstr ""
 
 #. English: "Next".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/player (pagination)
@@ -1272,6 +1322,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1310,6 +1365,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1419,6 +1479,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1463,6 +1528,11 @@ msgstr ""
 #. Priority for: Programmes
 msgid "release_date"
 msgstr "Tarehe ya kutolewa: %1"
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
+msgstr ""
 
 #. English: "Remove".
 #. Priority for: Favourites
@@ -1661,6 +1731,11 @@ msgstr "Onyesha wiki yote"
 #. Priority for: Schedules
 msgid "schedules_yesterday"
 msgstr "Jana"
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
+msgstr ""
 
 #. English: "%1s ago".
 #. %1 is a variable, which may contain the value: "1".

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -45,6 +45,11 @@ msgstr ""
 msgid "all_previous_episodes"
 msgstr ""
 
+#. English: "All programmes beginning with".
+#. Used by: RadioNav
+msgid "all_programmes_beginning_with"
+msgstr ""
+
 #. English: "All upcoming".
 #. Example URL: http://www.bbc.co.uk/programmes/b006m86d
 #. Priority for: Programmes
@@ -1360,6 +1365,11 @@ msgstr ""
 msgid "podcasts_more"
 msgstr ""
 
+#. English: "Search".
+#. Used by: RadioNav
+msgid "podcasts_search"
+msgstr ""
+
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
@@ -1475,6 +1485,11 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Programmes".
+#. Used by: RadioNav
+msgid "radionav_programmes"
 msgstr ""
 
 #. English: "Readings".
@@ -1733,6 +1748,11 @@ msgstr ""
 #. English: "Science & Nature".
 #. Used by: RadioNav -> Categories
 msgid "science_and_nature"
+msgstr ""
+
+#. English: "Search iPlayer Radio".
+#. Used by: RadioNav
+msgid "search_iplayer_radio"
 msgstr ""
 
 #. English: "%1s ago".

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -16,6 +16,11 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#. English: "All Categories".
+#. Used by: RadioNav -> Categories
+msgid "all_categories"
+msgstr ""
+
 #. English: "All episodes".
 #. Example URL: http://www.test.bbc.co.uk/programmes/b00cyj3f .
 #. Priority for: Programmes
@@ -49,6 +54,11 @@ msgstr ""
 #. English: "Artist name".
 #. Priority for: Rich Tracks
 msgid "artist_name"
+msgstr ""
+
+#. English: "Arts, Culture & the Media".
+#. Used by: RadioNav -> Categories
+msgid "arts_culture_and_the_media"
 msgstr ""
 
 #. English: "All Programmes".
@@ -360,6 +370,11 @@ msgstr ""
 msgid "colon_from_suppliers"
 msgstr ""
 
+#. English: "Comedy".
+#. Used by: RadioNav -> Categories
+msgid "comedy"
+msgstr ""
+
 #. English: "Coming soon".
 #. Priority for: Programmes
 msgid "coming_soon"
@@ -435,6 +450,11 @@ msgstr ""
 msgid "decade"
 msgstr ""
 
+#. English: "Documentaries".
+#. Used by: RadioNav -> Categories
+msgid "documentaries"
+msgstr ""
+
 #. English (no items): "Downloads".
 #. English (one item): "Download".
 #. English (2+ items): "Downloads".
@@ -446,8 +466,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Drama".
+#. Used by: RadioNav -> Categories
+msgid "drama"
+msgstr ""
+
 #. English: "Duration: %1".
 msgid "duration"
+msgstr ""
+
+#. English: "Entertainment".
+#. Used by: RadioNav -> Categories
+msgid "entertainment"
 msgstr ""
 
 #. English: "This episode will be available soon".
@@ -528,6 +558,11 @@ msgstr ""
 
 #. English: "There are no episodes".
 msgid "episodes_none"
+msgstr ""
+
+#. English: "Factual".
+#. Used by: RadioNav -> Categories
+msgid "factual"
 msgstr ""
 
 #. English: "Sorry, we couldn't access this information. Please refresh to try again.".
@@ -621,6 +656,11 @@ msgstr ""
 
 #. English: "Hide available episodes".
 msgid "hide_available_episodes"
+msgstr ""
+
+#. English: "History".
+#. Used by: RadioNav -> Categories
+msgid "history"
 msgstr ""
 
 #. English: "Home".
@@ -1129,6 +1169,11 @@ msgstr ""
 msgid "more_on_tv"
 msgstr ""
 
+#. English: "Music".
+#. Used by: RadioNav -> Categories
+msgid "music"
+msgstr ""
+
 #. English: "Music and featured items".
 msgid "music_and_featured"
 msgstr ""
@@ -1149,6 +1194,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006vq92 (visible at the time of writing, note that this text is only shown on new series)
 #. Priority for: Programmes
 msgid "new_series"
+msgstr ""
+
+#. English: "News".
+#. Used by: RadioNav -> Categories
+msgid "news"
 msgstr ""
 
 #. English: "Next".
@@ -1270,6 +1320,11 @@ msgstr ""
 msgid "pagination_page"
 msgstr ""
 
+#. English: "Performances & Events".
+#. Used by: RadioNav -> Categories
+msgid "performances_and_events"
+msgstr ""
+
 #. English: "Played:".
 #. Priority for: Rich Tracks
 msgid "played:"
@@ -1308,6 +1363,11 @@ msgstr ""
 #. English: "Other podcasts you may like".
 #. Example URL: http://www.bbc.co.uk/programmes/b006qpgr/episodes/downloads (you need to disable JavaScript to see this text)
 msgid "podcasts_suggestions"
+msgstr ""
+
+#. English: "Politics".
+#. Used by: RadioNav -> Categories
+msgid "politics"
 msgstr ""
 
 #. English: "Previous".
@@ -1417,6 +1477,11 @@ msgstr ""
 msgid "qr_link"
 msgstr ""
 
+#. English: "Readings".
+#. Used by: RadioNav -> Categories
+msgid "readings"
+msgstr ""
+
 #. English: "Recently played".
 msgid "recently_played"
 msgstr ""
@@ -1460,6 +1525,11 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/p027q949 (Hidden text for visually imapred users behind "1 October 2014")
 #. Priority for: Programmes
 msgid "release_date"
+msgstr ""
+
+#. English: "Religion & Ethics".
+#. Used by: RadioNav -> Categories
+msgid "religion_and_ethics"
 msgstr ""
 
 #. English: "Remove".
@@ -1658,6 +1728,11 @@ msgstr ""
 #. English: "Yesterday".
 #. Priority for: Schedules
 msgid "schedules_yesterday"
+msgstr ""
+
+#. English: "Science & Nature".
+#. Used by: RadioNav -> Categories
+msgid "science_and_nature"
 msgstr ""
 
 #. English: "%1s ago".


### PR DESCRIPTION
Added en, cy, ga and gd translations for Radionav of the following labels:

`comedy, drama, factual, music, news, science_and_nature, history, arts_culture_and_the_media, politics, entertainment, religion_and_ethics, performances_and_events, documentaries, readings, podcasts, all_categories, search_iplayer_radio, podcasts_search, all_programmes_beginning_with, radionav_programmes`