### PR TITLE
[IPR-3159] Updated translations for RadioNav

### DIFF
--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -1530,6 +1530,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -1536,6 +1536,10 @@ msgstr "Darlleniadau"
 msgid "recently_played"
 msgstr "Chwaraewyd yn ddiweddar"
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr "Gwelwyd yn ddiweddar"
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -1531,6 +1531,10 @@ msgstr "Readings"
 msgid "recently_played"
 msgstr "Recently played"
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr "Recently visited"
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -1529,6 +1529,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -1537,6 +1537,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -1532,6 +1532,10 @@ msgstr "Léamha"
 msgid "recently_played"
 msgstr "Seinnte le gairid"
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr "Gwelwyd yn ddiweddar"
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -284,9 +284,9 @@ msgstr ""
 #. English (2+ items): "Categories".
 msgid "categories"
 msgid_plural "categories %count%"
-msgstr[0] ""
+msgstr[0] "Roinnean"
 msgstr[1] ""
-msgstr[2] ""
+msgstr[2] "Roinnean"
 
 #. English: "This category can be found on the stations highlighted below".
 msgid "category_stations_note"
@@ -550,9 +550,9 @@ msgstr[2] ""
 #. Priority for: Programmes
 msgid "episodes"
 msgid_plural "episodes %count%"
-msgstr[0] ""
+msgstr[0] "Prògraman"
 msgstr[1] ""
-msgstr[2] ""
+msgstr[2] "Prògraman"
 
 #. English: "Episodes and clips".
 #. Priority for: Favourites
@@ -1466,9 +1466,9 @@ msgstr ""
 #. English (2+ items): "Programmes".
 msgid "programmes"
 msgid_plural "programmes %count%"
-msgstr[0] ""
+msgstr[0] "Prògraman"
 msgstr[1] ""
-msgstr[2] ""
+msgstr[2] "Prògraman"
 
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
@@ -1524,6 +1524,10 @@ msgstr "Leughaidhean"
 #. English: "Recently played".
 msgid "recently_played"
 msgstr "Air a chluich o chionn ghoirid"
+
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr "Air na thadhail thu"
 
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
@@ -1629,9 +1633,9 @@ msgstr ""
 #. Priority for: Schedules
 msgid "schedules"
 msgid_plural "schedules %count%"
-msgstr[0] ""
+msgstr[0] "Clàran"
 msgstr[1] ""
-msgstr[2] ""
+msgstr[2] "Clàran"
 
 #. English: "Boxing Day".
 msgid "schedules_boxing_day"
@@ -1940,7 +1944,7 @@ msgstr ""
 
 #. English: "Stations".
 msgid "stations"
-msgstr ""
+msgstr "Stèiseanan"
 
 #. English: "Subscribe".
 msgid "subscribe"

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -1526,6 +1526,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -1527,6 +1527,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -1526,6 +1526,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -1524,6 +1524,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -1527,6 +1527,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -1525,6 +1525,10 @@ msgstr ""
 msgid "recently_played"
 msgstr ""
 
+#. English: "Recently visited".
+msgid "recently_visited"
+msgstr ""
+
 #. English (no items): "Recipes".
 #. English (one item): "Recipe".
 #. English (2+ items): "Recipes".


### PR DESCRIPTION
Migration from https://github.com/bbc/radio-translations-reader left RadioNav with untranslated words. This PR updates it.

See https://jira.dev.bbc.co.uk/browse/IPR-3159