### PR TITLE
Nightingale additions needed for stations and schedules

### DIFF
--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -2075,11 +2075,6 @@ msgstr[2] "مواضيع"
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ar.po
+++ b/src/RMP/Translate/lang/programmes/ar.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -593,6 +598,11 @@ msgstr "الخاصية في ..."
 #. English: "Features".
 msgid "features"
 msgstr "خواص"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1471,6 +1481,11 @@ msgstr[0] "البرامج"
 msgstr[1] "البرنامج"
 msgstr[2] "البرامج"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1515,6 +1530,16 @@ msgstr "يمكنك حفظ، طباعة ومشاركة الصورة"
 msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2048,6 +2073,11 @@ msgstr[2] "مواضيع"
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/az.po
+++ b/src/RMP/Translate/lang/programmes/az.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/bn.po
+++ b/src/RMP/Translate/lang/programmes/bn.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -599,6 +604,11 @@ msgstr "Dan sylw yn..."
 #. English: "Features".
 msgid "features"
 msgstr "Dan Sylw"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1477,6 +1487,11 @@ msgstr[0] "Rhaglenni"
 msgstr[1] "Rhaglen"
 msgstr[2] "Rhaglenni"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1521,6 +1536,16 @@ msgstr "Gallwch arbed, argraffu neu rannu'r llun."
 msgid "qr_link"
 msgstr ""
 "Bydd y côd yn cysylltu â thudalen %1 trwy ddefnyddio darllenydd côd QR."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2061,6 +2086,11 @@ msgstr[2] "Pynciau"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Enw’r trac"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -9,7 +9,7 @@ msgstr ""
 #. English: "About BBC Radio".
 #. Used by: Radio Nightingale
 msgid "about_bbc_radio"
-msgstr ""
+msgstr "Am BBC Radio"
 
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
@@ -608,7 +608,7 @@ msgstr "Dan Sylw"
 #. English: "Feedback".
 #. Used by: Radio Nightingale
 msgid "feedback"
-msgstr ""
+msgstr "Adborth"
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1490,7 +1490,7 @@ msgstr[2] "Rhaglenni"
 #. English: "Programmes A-Z".
 #. Used by: Radio Nightingale
 msgid "programmes_a_z"
-msgstr ""
+msgstr "A-Z Rhaglenni Radio"
 
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
@@ -1540,12 +1540,12 @@ msgstr ""
 #. English: "Radio Blog".
 #. Used by: Radio Nightingale
 msgid "radio_blog"
-msgstr ""
+msgstr "Blog Radio"
 
 #. English: "iPlayer Radio Help".
 #. Used by: Radio Nightingale
 msgid "radio_help"
-msgstr ""
+msgstr "Help iPlayer Radio"
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2090,7 +2090,7 @@ msgstr "Enw’r trac"
 #. English: "Twitter".
 #. Used by: Radio Nightingale
 msgid "twitter"
-msgstr ""
+msgstr "Twitter"
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -2087,11 +2087,6 @@ msgstr[2] "Pynciau"
 msgid "track_title"
 msgstr "Enw’r trac"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr "Twitter"
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""
@@ -2197,3 +2192,4 @@ msgstr "Le"
 #. English: "You may also like".
 msgid "you_might_also_like"
 msgstr "Mwy o raglenni i chi"
+

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -9,7 +9,7 @@ msgstr ""
 #. English: "About BBC Radio".
 #. Used by: Radio Nightingale
 msgid "about_bbc_radio"
-msgstr ""
+msgstr "About BBC Radio"
 
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
@@ -603,7 +603,7 @@ msgstr "Features"
 #. English: "Feedback".
 #. Used by: Radio Nightingale
 msgid "feedback"
-msgstr ""
+msgstr "Feedback"
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1485,7 +1485,7 @@ msgstr[2] "Programmes"
 #. English: "Programmes A-Z".
 #. Used by: Radio Nightingale
 msgid "programmes_a_z"
-msgstr ""
+msgstr "Programmes A-Z"
 
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
@@ -1535,12 +1535,12 @@ msgstr ""
 #. English: "Radio Blog".
 #. Used by: Radio Nightingale
 msgid "radio_blog"
-msgstr ""
+msgstr "Radio Blog"
 
 #. English: "iPlayer Radio Help".
 #. Used by: Radio Nightingale
 msgid "radio_help"
-msgstr ""
+msgstr "iPlayer Radio Help"
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2082,7 +2082,7 @@ msgstr "Track title"
 #. English: "Twitter".
 #. Used by: Radio Nightingale
 msgid "twitter"
-msgstr ""
+msgstr "Twitter"
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -594,6 +599,11 @@ msgstr "Featured in..."
 #. English: "Features".
 msgid "features"
 msgstr "Features"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1472,6 +1482,11 @@ msgstr[0] "Programmes"
 msgstr[1] "Programme"
 msgstr[2] "Programmes"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1516,6 +1531,16 @@ msgstr "You may save, print or share the image."
 msgid "qr_link"
 msgstr ""
 "This code will link to the page for %1 when read using a QR code reader."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2053,6 +2078,11 @@ msgstr[2] "Topics"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Track title"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/en.po
+++ b/src/RMP/Translate/lang/programmes/en.po
@@ -2079,11 +2079,6 @@ msgstr[2] "Topics"
 msgid "track_title"
 msgstr "Track title"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr "Twitter"
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr "UK Only"
@@ -2189,3 +2184,4 @@ msgstr "Yes"
 #. English: "You may also like".
 msgid "you_might_also_like"
 msgstr "You may also like"
+

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/es.po
+++ b/src/RMP/Translate/lang/programmes/es.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -5,6 +5,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -593,6 +598,11 @@ msgstr "موجود در"
 #. English: "Features".
 msgid "features"
 msgstr "غیرخبری"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1471,6 +1481,11 @@ msgstr[0] "برنامه‌ها"
 msgstr[1] "برنامه"
 msgstr[2] "برنامه‌ها"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1514,6 +1529,16 @@ msgstr "شما می توانید این تصویر را ذخیره، چاپ یا
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "این کد با استفاده از کد خوان کیو آر صفحه اینترنتی %1 را باز خواهد کرد."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2048,6 +2073,11 @@ msgstr[2] "موضوعات"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "عنوان فایل صوتی"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/fa.po
+++ b/src/RMP/Translate/lang/programmes/fa.po
@@ -2074,11 +2074,6 @@ msgstr[2] "موضوعات"
 msgid "track_title"
 msgstr "عنوان فایل صوتی"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -2086,11 +2086,6 @@ msgstr[2] "Thèmes"
 msgid "track_title"
 msgstr "Titre du morceau"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/fr.po
+++ b/src/RMP/Translate/lang/programmes/fr.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -598,6 +603,11 @@ msgstr "Représenté dans..."
 #. English: "Features".
 msgid "features"
 msgstr "Éléments"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1476,6 +1486,11 @@ msgstr[0] "Programmes"
 msgstr[1] "Programme"
 msgstr[2] "Programmes"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1522,6 +1537,16 @@ msgid "qr_link"
 msgstr ""
 "Ce code vous amènera à la page de %1 lorsqu'il sera lu avec un lecteur de "
 "code QR."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2060,6 +2085,11 @@ msgstr[2] "Thèmes"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Titre du morceau"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -9,7 +9,7 @@ msgstr ""
 #. English: "About BBC Radio".
 #. Used by: Radio Nightingale
 msgid "about_bbc_radio"
-msgstr ""
+msgstr "Faoi BBC Raidió"
 
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
@@ -603,7 +603,7 @@ msgstr "Faoi thrácht"
 #. English: "Feedback".
 #. Used by: Radio Nightingale
 msgid "feedback"
-msgstr ""
+msgstr "Aischothú"
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1485,7 +1485,7 @@ msgstr[2] "Chlár"
 #. English: "Programmes A-Z".
 #. Used by: Radio Nightingale
 msgid "programmes_a_z"
-msgstr ""
+msgstr "Cláir A-Z"
 
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
@@ -1536,12 +1536,12 @@ msgstr ""
 #. English: "Radio Blog".
 #. Used by: Radio Nightingale
 msgid "radio_blog"
-msgstr ""
+msgstr "Blag Raidió"
 
 #. English: "iPlayer Radio Help".
 #. Used by: Radio Nightingale
 msgid "radio_help"
-msgstr ""
+msgstr "Cuidiú le Raidió ar iPlayer"
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2083,7 +2083,7 @@ msgstr "Teideal traic"
 #. English: "Twitter".
 #. Used by: Radio Nightingale
 msgid "twitter"
-msgstr ""
+msgstr "Twitter"
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -2080,11 +2080,6 @@ msgstr[2] "Toipicí"
 msgid "track_title"
 msgstr "Teideal traic"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr "Twitter"
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -594,6 +599,11 @@ msgstr "Faoi thrácht in..."
 #. English: "Features".
 msgid "features"
 msgstr "Faoi thrácht"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1472,6 +1482,11 @@ msgstr[0] "Clár"
 msgstr[1] "Chlár"
 msgstr[2] "Chlár"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1517,6 +1532,16 @@ msgid "qr_link"
 msgstr ""
 "Déanfaidh an cód seo nasc chuig an leathanach do %1 má bhíonn léitheoir cód "
 "QR cumasithe."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2054,6 +2079,11 @@ msgstr[2] "Toipicí"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Teideal traic"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -2070,11 +2070,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr "Tiotal"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr "Twitter"
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""
@@ -2180,3 +2175,4 @@ msgstr "Lean ort"
 #. English: "You may also like".
 msgid "you_might_also_like"
 msgstr ""
+

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] "Prògraman"
 msgstr[1] ""
 msgstr[2] "Prògraman"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1510,6 +1525,16 @@ msgstr ""
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "Ceanglaidh an còd air an taobh chlì ri duilleag %1 le còd QR."
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2044,6 +2069,11 @@ msgstr[2] ""
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Tiotal"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -9,7 +9,7 @@ msgstr ""
 #. English: "About BBC Radio".
 #. Used by: Radio Nightingale
 msgid "about_bbc_radio"
-msgstr ""
+msgstr "Mu BBC Radio"
 
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
@@ -601,7 +601,7 @@ msgstr ""
 #. English: "Feedback".
 #. Used by: Radio Nightingale
 msgid "feedback"
-msgstr ""
+msgstr "Beachdan"
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1483,7 +1483,7 @@ msgstr[2] "Prògraman"
 #. English: "Programmes A-Z".
 #. Used by: Radio Nightingale
 msgid "programmes_a_z"
-msgstr ""
+msgstr "Prògraman Rèidio A-Z"
 
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
@@ -1529,12 +1529,12 @@ msgstr "Ceanglaidh an còd air an taobh chlì ri duilleag %1 le còd QR."
 #. English: "Radio Blog".
 #. Used by: Radio Nightingale
 msgid "radio_blog"
-msgstr ""
+msgstr "Blog Rèidio"
 
 #. English: "iPlayer Radio Help".
 #. Used by: Radio Nightingale
 msgid "radio_help"
-msgstr ""
+msgstr "Taic iPlayer Radio"
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2073,7 +2073,7 @@ msgstr "Tiotal"
 #. English: "Twitter".
 #. Used by: Radio Nightingale
 msgid "twitter"
-msgstr ""
+msgstr "Twitter"
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -2069,11 +2069,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr "Sunan waka"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ha.po
+++ b/src/RMP/Translate/lang/programmes/ha.po
@@ -7,6 +7,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 "X-Loco-Target-Locale: cy_GB\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -592,6 +597,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1471,6 +1481,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1510,6 +1525,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2043,6 +2068,11 @@ msgstr[2] ""
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Sunan waka"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -592,6 +597,11 @@ msgstr "फ़ीचर्ड है"
 #. English: "Features".
 msgid "features"
 msgstr "फ़ीचर्स"
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
+msgstr ""
 
 #. English: "Filter by".
 msgid "filter_by"
@@ -1470,6 +1480,11 @@ msgstr[0] "कार्यक्रम"
 msgstr[1] "कार्यक्रम"
 msgstr[2] "कार्यक्रम"
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1512,6 +1527,16 @@ msgstr "इस इमेज को आप सेव, प्रिंट या �
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
 msgstr "क्यूआर कोड रीडर का इस्तेमाल करके पढ़े जाने पर ये कोड %1 के लिए बने पेज पर ले जाएगा"
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
+msgstr ""
 
 #. English: "Programmes".
 #. Used by: RadioNav
@@ -2044,6 +2069,11 @@ msgstr[2] "टॉपिक्स"
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "ट्रैक टाइटल"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/hi.po
+++ b/src/RMP/Translate/lang/programmes/hi.po
@@ -2070,11 +2070,6 @@ msgstr[2] "टॉपिक्स"
 msgid "track_title"
 msgstr "ट्रैक टाइटल"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/id.po
+++ b/src/RMP/Translate/lang/programmes/id.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -2069,11 +2069,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr "Атын издөө"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ky.po
+++ b/src/RMP/Translate/lang/programmes/ky.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -592,6 +597,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1471,6 +1481,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1510,6 +1525,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2043,6 +2068,11 @@ msgstr[2] ""
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Атын издөө"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/my.po
+++ b/src/RMP/Translate/lang/programmes/my.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ne.po
+++ b/src/RMP/Translate/lang/programmes/ne.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -2147,3 +2147,28 @@ msgstr ""
 #. English: "You may also like".
 msgid "you_might_also_like"
 msgstr ""
+
+#. English: "Twitter".
+msgid "twitter"
+msgstr ""
+
+#. English: "About BBC Radio".
+msgid "about_bbc_radio"
+msgstr ""
+
+#. English: "Radio Blog".
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+msgid "radio_help"
+msgstr ""
+
+#. English: "Feedback".
+msgid "feedback"
+msgstr ""
+
+#. English: "Programmes A-Z".
+msgid "programmes_a_z"
+msgstr ""
+

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -5,6 +5,11 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -590,6 +595,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1469,6 +1479,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1508,6 +1523,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2042,6 +2067,11 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
+
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""
@@ -2147,28 +2177,3 @@ msgstr ""
 #. English: "You may also like".
 msgid "you_might_also_like"
 msgstr ""
-
-#. English: "Twitter".
-msgid "twitter"
-msgstr ""
-
-#. English: "About BBC Radio".
-msgid "about_bbc_radio"
-msgstr ""
-
-#. English: "Radio Blog".
-msgid "radio_blog"
-msgstr ""
-
-#. English: "iPlayer Radio Help".
-msgid "radio_help"
-msgstr ""
-
-#. English: "Feedback".
-msgid "feedback"
-msgstr ""
-
-#. English: "Programmes A-Z".
-msgid "programmes_a_z"
-msgstr ""
-

--- a/src/RMP/Translate/lang/programmes/programmes.pot
+++ b/src/RMP/Translate/lang/programmes/programmes.pot
@@ -2067,11 +2067,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ps.po
+++ b/src/RMP/Translate/lang/programmes/ps.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/pt.po
+++ b/src/RMP/Translate/lang/programmes/pt.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ru.po
+++ b/src/RMP/Translate/lang/programmes/ru.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/rw.po
+++ b/src/RMP/Translate/lang/programmes/rw.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/si.po
+++ b/src/RMP/Translate/lang/programmes/si.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/so.po
+++ b/src/RMP/Translate/lang/programmes/so.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -2070,11 +2070,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr "Jina la kanda"
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/sw.po
+++ b/src/RMP/Translate/lang/programmes/sw.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -593,6 +598,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1472,6 +1482,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1511,6 +1526,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2044,6 +2069,11 @@ msgstr[2] ""
 #. Priority for: Rich Tracks
 msgid "track_title"
 msgstr "Jina la kanda"
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
+msgstr ""
 
 #. English: "UK Only".
 msgid "uk_only"

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ta.po
+++ b/src/RMP/Translate/lang/programmes/ta.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/tr.po
+++ b/src/RMP/Translate/lang/programmes/tr.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/ur.po
+++ b/src/RMP/Translate/lang/programmes/ur.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/uz.po
+++ b/src/RMP/Translate/lang/programmes/uz.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/vi.po
+++ b/src/RMP/Translate/lang/programmes/vi.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -2068,11 +2068,6 @@ msgstr[2] ""
 msgid "track_title"
 msgstr ""
 
-#. English: "Twitter".
-#. Used by: Radio Nightingale
-msgid "twitter"
-msgstr ""
-
 #. English: "UK Only".
 msgid "uk_only"
 msgstr ""

--- a/src/RMP/Translate/lang/programmes/zh.po
+++ b/src/RMP/Translate/lang/programmes/zh.po
@@ -6,6 +6,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"
 
+#. English: "About BBC Radio".
+#. Used by: Radio Nightingale
+msgid "about_bbc_radio"
+msgstr ""
+
 #. English: "Added".
 #. Used by: NHP -> MyRadioHeader
 msgid "added"
@@ -591,6 +596,11 @@ msgstr ""
 
 #. English: "Features".
 msgid "features"
+msgstr ""
+
+#. English: "Feedback".
+#. Used by: Radio Nightingale
+msgid "feedback"
 msgstr ""
 
 #. English: "Filter by".
@@ -1470,6 +1480,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. English: "Programmes A-Z".
+#. Used by: Radio Nightingale
+msgid "programmes_a_z"
+msgstr ""
+
 #. English (no items): "No programmes".
 #. English (one item): "1 programme".
 #. English (2+ items): "%1 programmes".
@@ -1509,6 +1524,16 @@ msgstr ""
 #. %1 is a variable, which may contain the value: "Doctor Who"
 #. Example URL: http://www.bbc.co.uk/programmes/b006q2x0/qrcode .
 msgid "qr_link"
+msgstr ""
+
+#. English: "Radio Blog".
+#. Used by: Radio Nightingale
+msgid "radio_blog"
+msgstr ""
+
+#. English: "iPlayer Radio Help".
+#. Used by: Radio Nightingale
+msgid "radio_help"
 msgstr ""
 
 #. English: "Programmes".
@@ -2041,6 +2066,11 @@ msgstr[2] ""
 #. English: "Track title".
 #. Priority for: Rich Tracks
 msgid "track_title"
+msgstr ""
+
+#. English: "Twitter".
+#. Used by: Radio Nightingale
+msgid "twitter"
 msgstr ""
 
 #. English: "UK Only".


### PR DESCRIPTION
re: 

https://jira.dev.bbc.co.uk/browse/IPR-3228
https://jira.dev.bbc.co.uk/browse/IPR-3227

The translations were for: 

"about_bbc_radio"
"feedback"
"programmes_a_z"
"radio_blog"
"radio_help"

to languages: 

English - en
Cymraeg (Welsh) - cy
Gaeilge (Irish) - ga
Gàidhlig (Scottish Gaelic) - gd

I ran `scripts/alphabetiseAllTranslations.sh programmes` to alphebatise then `scripts/updateTranslationsFromTemplate.sh programmes` to add new entries to the po files. 

@hammol04 could you review? 



