### PR TITLE
Change the way we do file loading. Always try to load en_GB.po AND en…

### DIFF
--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -129,7 +129,7 @@ class Translate
             $result = $this->translator->transChoice($key, $pluralisation, $substitutions, $domain, $locale);
         }
         // We don't want to return the key when the translation is not found (which is GetText standard behaviour)
-        if (!$this->translator->getCatalogue($locale)->defines($key, $domain)) {
+        if (!$this->translator->getCatalogue($locale)->has($key, $domain)) {
             return '';
         }
         return $result;

--- a/src/RMP/Translate/TranslateFactory.php
+++ b/src/RMP/Translate/TranslateFactory.php
@@ -42,8 +42,8 @@ class TranslateFactory
         );
         $options = array_merge($defaultOptions, $options);
 
-        $locale = $this->fixLocale($locale);
-        $options['fallback_locale'] = $this->fixLocale($options['fallback_locale']);
+        $locale = $this->fixDashes($locale);
+        $options['fallback_locale'] = $this->fixDashes($options['fallback_locale']);
 
         if (!in_array($options['default_domain'], $options['domains'])) {
             $options['default_domain'] = reset($options['domains']);
@@ -65,21 +65,17 @@ class TranslateFactory
             $options['basepath'] = __DIR__ . DIRECTORY_SEPARATOR . 'lang';
         }
 
-        $filesFound = false;
-
         $translator->addLoader('pofile', new PoFileLoader());
 
         // Allow multiple domains to be defined (e.g. 'radio' and 'programmes')
+        $fixedLocale = $this->stripUnderscores($locale);
         foreach ($options['domains'] as $domain) {
-            $path = $this->getFilePath($options['basepath'], $locale, $domain);
-            if ($path) {
-                $filesFound = true;
-                $translator->addResource(
-                    'pofile',
-                    $path,
-                    $locale,
-                    $domain
-                );
+            $this->addResource($translator, $options['basepath'], $locale, $domain);
+            if ($fixedLocale !== $locale) {
+                // We allow for translation files in the form en_GB.po (though we do not have any at present)
+                // and fallback to the version with the underscores stripped out.
+                // Symfony translate is smart enough to only blow up when neither is found
+                $this->addResource($translator, $options['basepath'], $fixedLocale, $domain);
             }
         }
 
@@ -89,17 +85,13 @@ class TranslateFactory
          * don't work properly. See https://github.com/symfony/symfony/issues/13483
          */
         if ($options['fallback_locale'] && $options['fallback_locale'] != $locale) {
+            $fixedLocale = $this->stripUnderscores($options['fallback_locale']);
             foreach ($options['domains'] as $domain) {
-                $path = $this->getFilePath($options['basepath'], $options['fallback_locale'], $domain);
-                if ($path) {
-                    $filesFound = true;
-                    $translator->addResource('pofile', $path, $options['fallback_locale'], $domain);
+                $this->addResource($translator, $options['basepath'], $options['fallback_locale'], $domain);
+                if ($fixedLocale !== $options['fallback_locale']) {
+                    $this->addResource($translator, $options['basepath'], $fixedLocale, $domain);
                 }
             }
-        }
-
-        if (!$filesFound) {
-            throw new TranslationFilesNotFoundException('No translation files found with basepath ' . $options['basepath']);
         }
 
         return new Translate($translator, $options['default_domain'], $locale, $options['fallback_locale']);
@@ -133,26 +125,29 @@ class TranslateFactory
      */
     protected function getFilePath($basePath, $locale, $domain)
     {
-        // Strip the _GB etc. bit off the locale for portability
-        if (strlen($locale) > 3) {
-            $locale = substr($locale, 0, -strlen(strrchr($locale, '_')));
-        }
+
+    }
+
+    protected function addResource($translator, $basePath, $locale, $domain)
+    {
         // Prevent anything nasty in the path
         $locale = preg_replace('/[^A-Za-z0-9_\-]/', '', $locale);
         $domain = preg_replace('/[^A-Za-z0-9_\-\.]/', '', $domain);
-        $temp = $basePath . DIRECTORY_SEPARATOR . $domain . DIRECTORY_SEPARATOR . $locale . '.po';
-        if (file_exists($temp)) {
-            return $temp;
+        $path = $basePath . DIRECTORY_SEPARATOR . $domain . DIRECTORY_SEPARATOR . $locale . '.po';
+        $translator->addResource(
+            'pofile',
+            $path,
+            $locale,
+            $domain
+        );
+    }
+
+    protected function stripUnderscores($locale)
+    {
+        if (strpos($locale, '_') !== false) {
+            return substr($locale, 0, -strlen(strstr($locale, '_')));
         }
-        // Search include paths
-        $paths = explode(':', get_include_path());
-        foreach ($paths as $path) {
-            $temp = $path . DIRECTORY_SEPARATOR . $basePath . DIRECTORY_SEPARATOR . $domain . DIRECTORY_SEPARATOR . $locale . '.po';
-            if (file_exists($temp)) {
-                return $temp;
-            }
-        }
-        return false;
+        return $locale;
     }
 
     /**
@@ -161,7 +156,7 @@ class TranslateFactory
      * @param string $locale
      * @return string
      */
-    protected function fixLocale($locale)
+    protected function fixDashes($locale)
     {
         return str_replace('-', '_', $locale);
     }

--- a/tests/RMP/Translate/TranslateFactoryTest.php
+++ b/tests/RMP/Translate/TranslateFactoryTest.php
@@ -39,10 +39,14 @@ class TranslateFactoryTest extends PHPUnit_Framework_TestCase
             'basepath' => __DIR__ . DIRECTORY_SEPARATOR . 'lang',
             'domains' => array('messages'),
         );
-        $poFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en.po';
-        $this->translator->expects($this->once())
+        $poFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en_GB.po';
+        $poFileFallbackPath = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en.po';
+        $this->translator->expects($this->exactly(2))
             ->method('addResource')
-            ->with($this->isType('string'), $this->equalTo($poFilePath), $this->stringContains('en'));
+            ->withConsecutive(
+                array($this->isType('string'), $this->equalTo($poFilePath), $this->stringContains('en')),
+                array($this->isType('string'), $this->equalTo($poFileFallbackPath), $this->stringContains('en'))
+            );
 
         $translate = $this->translateFactory->create('en-GB', $options);
         $this->assertInstanceOf('RMP\Translate\Translate', $translate);
@@ -55,13 +59,17 @@ class TranslateFactoryTest extends PHPUnit_Framework_TestCase
             'domains' => array('messages'),
             'fallback_locale' => 'en-GB'
         );
-        $poFilePath1 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru.po';
-        $poFilePath2 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en.po';
-        $this->translator->expects($this->exactly(2))
+        $poFilePath1 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru_RU.po';
+        $poFilePath1FB = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru.po';
+        $poFilePath2 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en_GB.po';
+        $poFilePath2FB = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'en.po';
+        $this->translator->expects($this->exactly(4))
             ->method('addResource')
             ->withConsecutive(
                 array($this->isType('string'), $this->equalTo($poFilePath1), $this->stringContains('ru')),
-                array($this->isType('string'), $this->equalTo($poFilePath2), $this->stringContains('en'))
+                array($this->isType('string'), $this->equalTo($poFilePath1FB), $this->stringContains('ru')),
+                array($this->isType('string'), $this->equalTo($poFilePath2), $this->stringContains('en')),
+                array($this->isType('string'), $this->equalTo($poFilePath2FB), $this->stringContains('en'))
             );
 
         $translate = $this->translateFactory->create('ru-RU', $options);
@@ -74,7 +82,7 @@ class TranslateFactoryTest extends PHPUnit_Framework_TestCase
             'basepath' => __DIR__ . DIRECTORY_SEPARATOR . 'lang',
             'default_domain' => 'otherdomain',
             'domains' => array('otherdomain'),
-            'fallback_locale' => 'en-GB'
+            'fallback_locale' => 'en'
         );
 
         $poFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'otherdomain' . DIRECTORY_SEPARATOR . 'en.po';
@@ -82,7 +90,7 @@ class TranslateFactoryTest extends PHPUnit_Framework_TestCase
             ->method('addResource')
             ->with($this->isType('string'), $this->equalTo($poFilePath), $this->stringContains('en'));
 
-        $translate = $this->translateFactory->create('en_GB', $options);
+        $translate = $this->translateFactory->create('en', $options);
         $this->assertInstanceOf('RMP\Translate\Translate', $translate);
     }
 
@@ -92,14 +100,18 @@ class TranslateFactoryTest extends PHPUnit_Framework_TestCase
             'basepath' => __DIR__ . DIRECTORY_SEPARATOR . 'lang',
             'domains' => array('messages', 'otherdomain')
         );
-        $poFilePath1 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru.po';
-        $poFilePath2 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'otherdomain' . DIRECTORY_SEPARATOR . 'ru.po';
+        $poFilePath1 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru_RU.po';
+        $poFilePath1FB = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . 'ru.po';
+        $poFilePath2 = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'otherdomain' . DIRECTORY_SEPARATOR . 'ru_RU.po';
+        $poFilePath2FB = __DIR__ . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . 'otherdomain' . DIRECTORY_SEPARATOR . 'ru.po';
 
-        $this->translator->expects($this->exactly(2))
+        $this->translator->expects($this->exactly(4))
             ->method('addResource')
             ->withConsecutive(
                 array($this->isType('string'), $this->equalTo($poFilePath1), $this->stringContains('ru')),
-                array($this->isType('string'), $this->equalTo($poFilePath2), $this->stringContains('ru'))
+                array($this->isType('string'), $this->equalTo($poFilePath1FB), $this->stringContains('ru')),
+                array($this->isType('string'), $this->equalTo($poFilePath2), $this->stringContains('ru')),
+                array($this->isType('string'), $this->equalTo($poFilePath2FB), $this->stringContains('ru'))
             );
 
         $translate = $this->translateFactory->create('ru-RU', $options);

--- a/tests/RMP/Translate/TranslateTest.php
+++ b/tests/RMP/Translate/TranslateTest.php
@@ -42,7 +42,7 @@ class TranslateTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('teststring'));
 
         $this->catalogue->expects($this->once())
-            ->method('defines')
+            ->method('has')
             ->with('key')
             ->will($this->returnValue(true));
 
@@ -61,7 +61,7 @@ class TranslateTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('teststring'));
 
         $this->catalogue->expects($this->once())
-            ->method('defines')
+            ->method('has')
             ->with('key %count%')
             ->will($this->returnValue(true));
 
@@ -83,7 +83,7 @@ class TranslateTest extends PHPUnit_Framework_TestCase
             )->will($this->onConsecutiveCalls('', 'fallbackstring'));
 
         $this->catalogue->expects($this->exactly(2))
-            ->method('defines')
+            ->method('has')
             ->with('keyname')
             ->will($this->returnValue(true));
 
@@ -105,7 +105,7 @@ class TranslateTest extends PHPUnit_Framework_TestCase
             )->will($this->onConsecutiveCalls('keyname', 'fallbackstring'));
 
         $this->catalogue->expects($this->exactly(2))
-            ->method('defines')
+            ->method('has')
             ->with('keyname')
             ->will($this->onConsecutiveCalls(false, true));
 


### PR DESCRIPTION
….po and allow symfony to switch and cache without our involvement. This needs testing.

This is a fairly major change to the way this does file loading under the bonnet. It SHOULD not have any effects on the client other than fixing the bug in https://github.com/bbc/rmp-translate/issues/35 , but it needs proper testing in a client app before I would trust it with anything.

This also allows for us to support en_GB, en_US (for example) as separate things in the future. 