### PR TITLE
check against padded locale

### DIFF
--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -90,6 +90,11 @@ class Translate
         }
         $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale);
 
+        // test if the locale is the 2 letter variant which is oftent taken from ckps_language
+        if ($result === '' && strlen($this->locale) == 2) {
+            $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale . '_GB');
+        }
+
         /**
          * We explicitly check the default and fallback locales rather than rely on Symfony's fallback
          * locale because it's PO file parsing is broken and therefore fallback locales

--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -91,7 +91,8 @@ class Translate
         $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale);
 
         // test if the locale is the 2 letter variant which is oftent taken from ckps_language
-        if ($result === '' && strlen($this->locale) == 2) {
+        $gbLocales = ['en','cy','gd','ga'];
+        if ($result === '' && in_array($this->locale, $gbLocales)) {
             $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale . '_GB');
         }
 

--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -91,7 +91,7 @@ class Translate
         $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale);
 
         // test if the locale is the 2 letter variant which is oftent taken from ckps_language
-        $gbLocales = ['en','cy','gd','ga'];
+        $gbLocales = array('en','cy','gd','ga');
         if ($result === '' && in_array($this->locale, $gbLocales)) {
             $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale . '_GB');
         }


### PR DESCRIPTION
Adding a case that pads the locale when it has been passed through as the 2 letter format. 

i.e. `en` rather than `en_GB`