### PR TITLE
revert locale padding

### DIFF
--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -90,12 +90,6 @@ class Translate
         }
         $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale);
 
-        // test if the locale is the 2 letter variant which is oftent taken from ckps_language
-        $gbLocales = array('en','cy','gd','ga');
-        if ($result === '' && in_array($this->locale, $gbLocales)) {
-            $result = $this->_translate($key, $substitutions, $pluralisation, $domain, $this->locale . '_GB');
-        }
-
         /**
          * We explicitly check the default and fallback locales rather than rely on Symfony's fallback
          * locale because it's PO file parsing is broken and therefore fallback locales


### PR DESCRIPTION
The issue had gone away after this was deployed but it appears not to the credit of this change. 

We are unsure yet how this issue went away but removing this change as it is not needed