### PR TITLE
Add setLocale to Translate

### DIFF
--- a/src/RMP/Translate/Translate.php
+++ b/src/RMP/Translate/Translate.php
@@ -164,6 +164,15 @@ class Translate
     }
 
     /**
+     * @param string $setLocale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+        PluralizationRules::set(array($this, 'pluralisationRule'), $this->locale);
+    }
+
+    /**
      * @return string
      */
     public function getDomain()

--- a/tests/RMP/Translate/TranslateTest.php
+++ b/tests/RMP/Translate/TranslateTest.php
@@ -36,19 +36,26 @@ class TranslateTest extends PHPUnit_Framework_TestCase
     {
         $domain = 'messages';
         $locale = 'en';
-        $this->translator->expects($this->once())
+        $secondLocale = 'zz';
+        $this->translator->expects($this->exactly(2))
             ->method('trans')
-            ->with('key', array(), $domain, $locale)
-            ->will($this->returnValue('teststring'));
+            ->withConsecutive(
+                array('key', array(), $domain, $locale),
+                array('key', array(), $domain, $secondLocale)
+            )
+            ->will($this->onConsecutiveCalls('en_result', 'zz_result'));
 
-        $this->catalogue->expects($this->once())
+        $this->catalogue->expects($this->exactly(2))
             ->method('defines')
             ->with('key')
             ->will($this->returnValue(true));
 
         $translate = new Translate($this->translator, $domain, $locale);
-        $value = $translate->translate('key');
-        $this->assertEquals('teststring', $value);
+        $this->assertEquals('en_result', $translate->translate('key'));
+
+        // Test setting the Locale changes it
+        $translate->setLocale('zz');
+        $this->assertEquals('zz_result', $translate->translate('key'));
     }
 
     public function testPluralTranslation()


### PR DESCRIPTION
This allows us to modify an existing instance of Translate, instead of
having to create a whole new one when we need to change the locale