### PR TITLE
Handle locale string without underscore 

### DIFF
--- a/src/RMP/Translate/TranslateFactory.php
+++ b/src/RMP/Translate/TranslateFactory.php
@@ -138,7 +138,7 @@ class TranslateFactory
     {
         // Strip the _GB etc. bit off the locale for portability
         if (strlen($locale) > 3) {
-            $locale = substr($locale, 0, -strlen(strrchr($locale, '_')));
+            $locale = preg_replace('/_[^_]+$/', '', $locale);
         }
         // Prevent anything nasty in the path
         $locale = preg_replace('/[^A-Za-z0-9_\-]/', '', $locale);

--- a/src/RMP/Translate/TranslateFactory.php
+++ b/src/RMP/Translate/TranslateFactory.php
@@ -137,9 +137,7 @@ class TranslateFactory
     protected function getFilePath($basePath, $locale, $domain)
     {
         // Strip the _GB etc. bit off the locale for portability
-        if (strpos($locale, '_') !== false) {
-            $locale = substr($locale, 0, -strlen(strstr($locale, '_')));
-        }
+        $locale = $this->truncateLocaleString($locale);
 
         // Prevent anything nasty in the path
         $locale = preg_replace('/[^A-Za-z0-9_\-]/', '', $locale);
@@ -168,5 +166,20 @@ class TranslateFactory
     protected function fixLocale($locale)
     {
         return str_replace('-', '_', $locale);
+    }
+
+    /**
+     * Strips everything after and including the first underscore in the string.
+     *
+     * @param string $locale
+     * @return string
+     */
+    protected function truncateLocaleString($locale)
+    {
+        if (strpos($locale, '_') !== false) {
+            $locale = substr($locale, 0, -strlen(strstr($locale, '_')));
+        }
+
+        return $locale;
     }
 }

--- a/src/RMP/Translate/TranslateFactory.php
+++ b/src/RMP/Translate/TranslateFactory.php
@@ -137,9 +137,10 @@ class TranslateFactory
     protected function getFilePath($basePath, $locale, $domain)
     {
         // Strip the _GB etc. bit off the locale for portability
-        if (strlen($locale) > 3) {
-            $locale = preg_replace('/_[^_]+$/', '', $locale);
+        if (strpos($locale, '_') !== false) {
+            $locale = substr($locale, 0, -strlen(strstr($locale, '_')));
         }
+
         // Prevent anything nasty in the path
         $locale = preg_replace('/[^A-Za-z0-9_\-]/', '', $locale);
         $domain = preg_replace('/[^A-Za-z0-9_\-\.]/', '', $domain);

--- a/tests/RMP/Translate/LocaleTruncationTest.php
+++ b/tests/RMP/Translate/LocaleTruncationTest.php
@@ -33,6 +33,7 @@ class LocaleTruncationTest extends PHPUnit_Framework_TestCase
     {
         return [
             'general' => ['en_GB', 'en'],
+            'multiple' => ['en_GB_GB', 'en'],
             'short' => ['en', 'en'],
             'noSuffix' => ['articles', 'articles'],
         ];

--- a/tests/RMP/Translate/LocaleTruncationTest.php
+++ b/tests/RMP/Translate/LocaleTruncationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Test\RMP\Translate;
+
+use PHPUnit_Framework_TestCase;
+use ReflectionMethod;
+use RMP\Translate\TranslateFactory;
+
+/**
+ * Class LocaleTruncationTest
+ *
+ * This tests the truncateLocaleString method in the TranslateFactory.
+ *
+ * @package RMP\Translate
+ */
+class LocaleTruncationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider localeProvider
+     */
+    public function testTruncateLocaleString($locale)
+    {
+        $method = new ReflectionMethod('RMP\Translate\TranslateFactory', 'truncateLocaleString');
+        $method->setAccessible(true);
+
+        $translateFactory = new TranslateFactory();
+        $result = $method->invoke($translateFactory, $locale);
+
+        $this->assertEquals('en', $result);
+    }
+
+    public function localeProvider()
+    {
+        return [
+            'general' => ['en_GB'],
+            'noSuffix' => ['en'],
+        ];
+    }
+}

--- a/tests/RMP/Translate/LocaleTruncationTest.php
+++ b/tests/RMP/Translate/LocaleTruncationTest.php
@@ -18,7 +18,7 @@ class LocaleTruncationTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider localeProvider
      */
-    public function testTruncateLocaleString($locale)
+    public function testTruncateLocaleString($locale, $expected)
     {
         $method = new ReflectionMethod('RMP\Translate\TranslateFactory', 'truncateLocaleString');
         $method->setAccessible(true);
@@ -26,14 +26,15 @@ class LocaleTruncationTest extends PHPUnit_Framework_TestCase
         $translateFactory = new TranslateFactory();
         $result = $method->invoke($translateFactory, $locale);
 
-        $this->assertEquals('en', $result);
+        $this->assertEquals($expected, $result);
     }
 
     public function localeProvider()
     {
         return [
-            'general' => ['en_GB'],
-            'noSuffix' => ['en'],
+            'general' => ['en_GB', 'en'],
+            'short' => ['en', 'en'],
+            'noSuffix' => ['articles', 'articles'],
         ];
     }
 }


### PR DESCRIPTION
Fix `getFilePath()` setting `$locale` to an empty string when no underscore is present