### PR TITLE
Changed categories strings

### DIFF
--- a/src/RMP/Translate/lang/programmes/cy.po
+++ b/src/RMP/Translate/lang/programmes/cy.po
@@ -316,9 +316,9 @@ msgstr[2] "Categorïau"
 msgid "categories_noresults"
 msgstr "Ymddiheuriadau ond does dim canlyniadau ar gyfer y categori hwn"
 
-#. English: "Pick a category to see BBC Radio programmes".
+#. English: "Select a category to browse radio shows, podcasts or music mixes".
 msgid "categories_subheading"
-msgstr "Dewiswch gategori er mwyn gweld rhaglenni BBC Radio"
+msgstr "Dewiswch gategori er mwyn chwilio drwy raglenni radio, podlediadau neu gymysgiadau cerddoriaeth"
 
 #. English: "This category can be found on the stations highlighted below".
 msgid "category_stations_note"

--- a/src/RMP/Translate/lang/programmes/ga.po
+++ b/src/RMP/Translate/lang/programmes/ga.po
@@ -315,9 +315,9 @@ msgstr[2] "Catagóirí"
 msgid "categories_noresults"
 msgstr "Buartha, níl toradh ar bith don chatagóir seo"
 
-#. English: "Pick a category to see BBC Radio programmes".
+#. English: "Select a category to browse radio shows, podcasts or music mixes".
 msgid "categories_subheading"
-msgstr "Roghnaigh catagóir le cláir BBC Radio a fheiceáil"
+msgstr "Tagh roinn is lorg prògraman rèidio, podcastan no ceòl."
 
 #. English: "This category can be found on the stations highlighted below".
 msgid "category_stations_note"

--- a/src/RMP/Translate/lang/programmes/gd.po
+++ b/src/RMP/Translate/lang/programmes/gd.po
@@ -315,9 +315,9 @@ msgstr[2] "Roinnean"
 msgid "categories_noresults"
 msgstr "Duilich, chan eil toraidhean ann airson an roinn seo"
 
-#. English: "Pick a category to see BBC Radio programmes".
+#. English: "Select a category to browse radio shows, podcasts or music mixes".
 msgid "categories_subheading"
-msgstr "Tagh roinn airson prògraman BBC Radio fhaicinn"
+msgstr "Roghnaigh catagóir le brabhsáil a dhéanamh ar chláir raidió, podchroaltaí agus meascthaí ceoil"
 
 #. English: "This category can be found on the stations highlighted below".
 msgid "category_stations_note"

--- a/src/RMP/Translate/lang/programmes/uk.po
+++ b/src/RMP/Translate/lang/programmes/uk.po
@@ -315,7 +315,7 @@ msgstr[2] ""
 msgid "categories_noresults"
 msgstr ""
 
-#. English: "Pick a category to see BBC Radio programmes".
+#. English: "Select a category to browse radio shows, podcasts or music mixes".
 msgid "categories_subheading"
 msgstr ""
 


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/SOUNDS-3366

Copy needs to be updated on the following page: https://www.bbc.co.uk/sounds/categories

Specifically the copy at the top of the page that says:
"Pick a category to see BBC Radio programmes"

It should reflect Sounds tone of voice and terminology.